### PR TITLE
fix: Improve check_missing_programs

### DIFF
--- a/benchs/base.py
+++ b/benchs/base.py
@@ -36,6 +36,12 @@ class Bench(object):
     def docker_sys_cmd(self, dev):
         return "docker run -v \"%s:%s\" -v \"%s:/output\" --privileged=true" % (dev, dev, self.output)
 
+    def required_host_tools(self):
+        return {'blkzone', 'blkdiscard'}
+
+    def required_container_tools(self):
+        return set()
+
     def sys_cmd(self, tool, dev, container):
         exec_cmd = tool
         container_cmd = ''

--- a/benchs/fio_zone_mixed.py
+++ b/benchs/fio_zone_mixed.py
@@ -17,6 +17,9 @@ class Run(Bench):
 
         self.discard_dev(dev)
 
+    def required_container_tools(self):
+        return super().required_container_tools() |  {'fio'}
+
     def run(self, dev, container):
         extra = ''
         max_open_zones = 14

--- a/benchs/fio_zone_randr_seqw_seqr_rrsw.py
+++ b/benchs/fio_zone_randr_seqw_seqr_rrsw.py
@@ -17,6 +17,9 @@ class Run(Bench):
 
         self.discard_dev(dev)
 
+    def required_container_tools(self):
+        return super().required_container_tools() |  {'fio'}
+
     def run(self, dev, container):
         extra = ''
         max_open_zones = 14

--- a/benchs/fio_zone_throughput_avg_lat.py
+++ b/benchs/fio_zone_throughput_avg_lat.py
@@ -110,6 +110,9 @@ class Run(Bench):
 
         self.discard_dev(dev)
 
+    def required_container_tools(self):
+        return super().required_container_tools() |  {'fio'}
+
     def run(self, dev, container):
         extra = ''
 

--- a/benchs/fio_zone_writes.py
+++ b/benchs/fio_zone_writes.py
@@ -19,6 +19,9 @@ class Run(Bench):
 
         self.discard_dev(dev)
 
+    def required_container_tools(self):
+        return super().required_container_tools() |  {'fio'}
+
     def run(self, dev, container):
         extra = ''
         max_open_zones = 14

--- a/benchs/rocksdb.py
+++ b/benchs/rocksdb.py
@@ -41,6 +41,12 @@ class RocksDBBase(Bench):
 
     write_limit = str(1024 * 1024 * 20) # 20MB/s
 
+    def required_container_tools(self):
+        return super().required_container_tools() | {
+            'zenfs',
+            'db_bench',
+        }
+
     def get_target_fz_base(self, dev):
         zonecap = self.get_zone_capacity_mb(dev)
         return str(int(zonecap * 95 / 100) * 1024 * 1024)

--- a/benchs/template.py
+++ b/benchs/template.py
@@ -21,6 +21,12 @@ class Run(Bench):
 
         self.discard_dev(dev)
 
+    def required_host_tools(self):
+        return super().required_host_tools() |  {'some_tool'}
+
+    def required_container_tools(self):
+        return super().required_container_tools() |  {'some_tool'}
+
     def run(self, dev, container):
         bdev = self.sys_container_dev(dev, container)
         fio_params = "fio_params"


### PR DESCRIPTION
We do not need to check for tools that is not required to run the selected benchmarks.

Signed-off-by: Andreas Hindborg <andreas.hindborg@wdc.com>