### PR TITLE
Remove `nvme` dependency

### DIFF
--- a/benchs/base.py
+++ b/benchs/base.py
@@ -105,6 +105,14 @@ class Bench(object):
 
         return int(zonecap * bs / 1024 / 1024)
 
+    def get_drive_size_gb(self, path):
+        filename = path + "/nvme_id-ns.txt"
+        with open(filename, 'r') as f:
+            for l in f:
+                if 'nvmcap' in l:
+                    return int(int(l.strip("nvmcap  : ")) / 1024 / 1024 / 1024)
+        return None
+
     def discard_dev(self, dev):
 #        v = raw_input('Do you want to discard (y/N)?')
 #        if v != 'y':

--- a/benchs/base.py
+++ b/benchs/base.py
@@ -105,7 +105,7 @@ class Bench(object):
 
         return int(zonecap * bs / 1024 / 1024)
 
-    def get_drive_size_gb(self, path):
+    def get_nvme_drive_capacity_gb(self, path):
         filename = path + "/nvme_id-ns.txt"
         with open(filename, 'r') as f:
             for l in f:

--- a/benchs/fio_zone_writes.py
+++ b/benchs/fio_zone_writes.py
@@ -52,9 +52,9 @@ class Run(Bench):
 
     def report(self, path):
 
-        devsize = self.get_drive_size_gb(path)
-        if devsize is None:
-            print("Could not get drive size for report")
+        devcap = self.get_nvme_drive_capacity_gb(path)
+        if devcap is None:
+            print("Could not get drive capacity for report")
             sys.exit(1)
 
         dp = []
@@ -66,8 +66,8 @@ class Run(Bench):
             for n in data:
                 dy.append(int(n[1]) / 1024)
 
-        ds = range(0, devsize)
-        sum_max = sum(dy) / devsize
+        ds = range(0, devcap)
+        sum_max = sum(dy) / devcap
 
         spill = 0
         prev = 0

--- a/benchs/fio_zone_writes.py
+++ b/benchs/fio_zone_writes.py
@@ -50,14 +50,6 @@ class Run(Bench):
     def teardown(self, dev, container):
         pass
 
-    def get_drive_size_gb(self, path):
-        filename = path + "/nvme_id-ns.txt"
-        with open(filename, 'r') as f:
-            for l in f:
-                if 'nvmcap' in l:
-                    return int(int(l.strip("nvmcap  : ")) / 1024 / 1024 / 1024)
-        return None
-
     def report(self, path):
 
         devsize = self.get_drive_size_gb(path)

--- a/benchs/rocksdb.py
+++ b/benchs/rocksdb.py
@@ -91,9 +91,9 @@ class RocksDBBase(Bench):
                 return [i for i in line.split(' ') if i]
 
     def report(self, path):
-        devsize = self.get_drive_size_gb(path)
-        if devsize is None:
-            print("Could not get drive size for report")
+        devcap = self.get_nvme_drive_capacity_gb(path)
+        if devcap is None:
+            print("Could not get drive capacity for report")
             sys.exit(1)
 
         print("  Output written to: ")

--- a/benchs/rocksdb.py
+++ b/benchs/rocksdb.py
@@ -72,14 +72,6 @@ class RocksDBBase(Bench):
 
         return ''.join(params)
 
-    def get_drive_size_gb(self, path):
-        filename = path + "/nvme_id-ns.txt"
-        with open(filename, 'r') as f:
-            for l in f:
-                if 'nvmcap' in l:
-                    return int(l.strip("nvmcap  : ")) / 1024 / 1024 / 1024
-        return None
-
     def create_csv_file(self, filename):
         try:
             with open(filename, 'x') as f:

--- a/run.py
+++ b/run.py
@@ -60,7 +60,7 @@ def check_dev_zoned(dev):
 
 def check_missing_programs(container, benchmarks):
 
-    host_tools = {'nvme'}
+    host_tools = {'blkzone'}
     container_tools = set()
 
     for benchmark in benchmarks:
@@ -92,12 +92,11 @@ def create_dirs(run_output):
         sys.exit(1)
 
 def collect_info(dev, run_output):
-    subprocess.call("nvme id-ctrl -H %s > %s/nvme_id-ctrl.txt" % (dev, run_output), shell=True)
-    subprocess.call("nvme id-ns -H %s > %s/nvme_id-ns.txt" % (dev, run_output), shell=True)
+    subprocess.call(f"lsblk -b {dev} > lsblk-capacity.txt", shell=True)
 
     if is_dev_zoned(dev):
-        subprocess.call("nvme zns id-ns -H %s > %s/nvme_zns_id-ns.txt" % (dev, run_output), shell=True)
-        subprocess.call("nvme zns report-zones -H %s > %s/nvme_zns_report-zones.txt" % (dev, run_output), shell=True)
+        subprocess.call(f"blkzone capacity {dev} > {run_output}/blkzone-capacity.txt", shell=True)
+        subprocess.call(f"blkzone report {dev} > {run_output}/blkzone-report.txt", shell=True)
 
 def list_benchs(benches):
     print("\nBenchmarks:")


### PR DESCRIPTION
Running `nvme` requires root. We can get the info we need in ways that do not require root (if device is owned by user).                                   