### PR TITLE
feat: Introduce default device scheduler for benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,18 @@ Regenerate plots from existing csv report
 
     ./run.py -b fio_zone_throughput_avg_lat -p output/YYYYMMDDHHMMSS/fio_zone_throughput_avg_lat.csv
 
-Run specific benchmark with the none scheduler:
+Overwrite benchmark run with the none device scheduler:
 
     ./run.py -b benchmark -d /dev/nvmeXnY --none-scheduler
 
+Overwrite benchmark run with the mq-deadline device scheduler:
+
+    ./run.py -b benchmark -d /dev/nvmeXnY --mq-deadline-scheduler
+
 Benchmarks
 ----------
+
+All fio benchmarks are setting the none scheduler by default.
 
 fio_zone_write
   - executes a fio workload that writes sequential to 14 zones in parallel and

--- a/benchs/base.py
+++ b/benchs/base.py
@@ -5,9 +5,15 @@ import csv
 import os
 import matplotlib.pyplot as plt
 import fileinput
+from enum import Enum
 
 # Global list of available benchmarks
 base_benches = []
+
+# Enum for device scheduler
+class DeviceScheduler(Enum):
+    NONE = 1
+    MQ_DEADLINE = 2
 
 # Generic class that a benchmark definition must implement.
 class Bench(object):
@@ -32,6 +38,9 @@ class Bench(object):
 
     def plot(self, csv_file):
         print("Not implemented (plot)")
+
+    def get_default_device_scheduler(self):
+        return DeviceScheduler.MQ_DEADLINE
 
     # Helpers
     def docker_sys_cmd(self, dev):

--- a/benchs/fio_zone_mixed.py
+++ b/benchs/fio_zone_mixed.py
@@ -1,6 +1,6 @@
 import json
 import csv
-from .base import base_benches, Bench
+from .base import base_benches, Bench, DeviceScheduler
 from benchs.base import is_dev_zoned
 
 class Run(Bench):
@@ -8,6 +8,9 @@ class Run(Bench):
 
     def __init__(self):
         pass
+
+    def get_default_device_scheduler(self):
+        return DeviceScheduler.NONE
 
     def id(self):
         return self.jobname

--- a/benchs/fio_zone_randr_seqw_seqr_rrsw.py
+++ b/benchs/fio_zone_randr_seqw_seqr_rrsw.py
@@ -1,6 +1,6 @@
 import json
 import csv
-from .base import base_benches, Bench
+from .base import base_benches, Bench, DeviceScheduler
 from benchs.base import is_dev_zoned
 
 class Run(Bench):
@@ -8,6 +8,9 @@ class Run(Bench):
 
     def __init__(self):
         pass
+
+    def get_default_device_scheduler(self):
+        return DeviceScheduler.NONE
 
     def id(self):
         return self.jobname

--- a/benchs/fio_zone_throughput_avg_lat.py
+++ b/benchs/fio_zone_throughput_avg_lat.py
@@ -5,7 +5,7 @@ import glob
 import re
 import math
 import matplotlib.pyplot as plt
-from .base import base_benches, Bench, Plot
+from .base import base_benches, Bench, Plot, DeviceScheduler
 from benchs.base import is_dev_zoned
 
 operation_list = ["read", "randread", "write"]
@@ -168,6 +168,9 @@ class Run(Bench):
 
     def __init__(self):
         pass
+
+    def get_default_device_scheduler(self):
+        return DeviceScheduler.NONE
 
     def id(self):
         return self.jobname

--- a/benchs/fio_zone_writes.py
+++ b/benchs/fio_zone_writes.py
@@ -1,7 +1,7 @@
 import csv
 import sys
 from statistics import mean
-from .base import base_benches, Bench
+from .base import base_benches, Bench, DeviceScheduler
 from benchs.base import is_dev_zoned
 
 class Run(Bench):
@@ -10,6 +10,9 @@ class Run(Bench):
 
     def __init__(self):
         pass
+
+    def get_default_device_scheduler(self):
+        return DeviceScheduler.NONE
 
     def id(self):
         return self.jobname


### PR DESCRIPTION
The default device scheduler may be overwritten by the arguments
`--none-scheduler` or `--mq-deadline-scheduler`.

Signed-off-by: Dennis Maisenbacher <dennis.maisenbacher@wdc.com>