### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ validating that it is about to write to a block device, not mounted, and ready.
 
 After all benchmarks have run, their output is availble in:
 
-    output/YYYYMMDDHHMMSS (date format is replaced with the current time)
+    zbdbench_results/YYYYMMDDHHMMSS (date format is replaced with the current time)
 
 Each benchmark has a report function, which creates a csv file with the
 specific output. See the section below for the csv format for each benchmark.
@@ -37,8 +37,9 @@ To execute the benchmarks, run:
 If you have the latest fio installed, you may skip the container installation and
 run the benchmarks using the system commands.
 
-    sudo ./run.py -d /dev/nvmeXnY -c system
+    sudo ./run.py -d /dev/nvmeXnY -c no
 
+NOTE: If -c option is not provided, default is '-c yes'.
 To list available benchmarks, run:
 
     ./run.py -l
@@ -64,11 +65,11 @@ Run all benchmarks:
 
 Regenerate a report (and its plots)
 
-    ./run.py -b fio_zone_mixed -r output/YYYYMMDDHHMMSS
+    ./run.py -b fio_zone_mixed -r zbdbench_results/YYYYMMDDHHMMSS
 
 Regenerate plots from existing csv report
 
-    ./run.py -b fio_zone_throughput_avg_lat -p output/YYYYMMDDHHMMSS/fio_zone_throughput_avg_lat.csv
+    ./run.py -b fio_zone_throughput_avg_lat -p zbdbench_results/YYYYMMDDHHMMSS/fio_zone_throughput_avg_lat.csv
 
 Overwrite benchmark run with the none device scheduler:
 

--- a/benchs/base.py
+++ b/benchs/base.py
@@ -33,7 +33,7 @@ class Bench(object):
     def teardown(self):
         print("Not implemented (teardown)")
 
-    def report(self, path):
+    def report(self, dev, path):
         print("Not implemented (report)")
 
     def plot(self, csv_file):
@@ -44,7 +44,7 @@ class Bench(object):
 
     # Helpers
     def container_sys_cmd(self, dev, extra_params):
-        return f"podman run -v \"{dev}:{dev}\" -v \"{self.output}:/output\" {extra_params}"
+        return f"podman run --privileged -v \"{dev}:{dev}\" -v \"{self.output}:/output\" {extra_params}"
 
     def required_host_tools(self):
         return {'blkzone', 'blkdiscard'}
@@ -126,8 +126,8 @@ class Bench(object):
 
         return sectorsize
 
-    def get_nvme_drive_capacity_gb(self, path):
-        if is_dev_zoned(path):
+    def get_nvme_drive_capacity_gb(self, dev, path):
+        if is_dev_zoned(dev):
             filename = path + "/blkzone-capacity.txt"
             with open(filename, 'r') as f:
                 size_blocks = int(f.read().strip(), 0)

--- a/benchs/base.py
+++ b/benchs/base.py
@@ -126,9 +126,10 @@ class Bench(object):
 
         return sectorsize
 
-    def get_nvme_drive_capacity_gb(self, dev, path):
-        if is_dev_zoned(dev):
-            filename = path + "/blkzone-capacity.txt"
+    def get_nvme_drive_capacity_gb(self, path):
+        filename = path + "/blkzone-capacity.txt"
+        zoned_dev = os.path.exists(filename)
+        if zoned_dev:
             with open(filename, 'r') as f:
                 size_blocks = int(f.read().strip(), 0)
                 size_bytes = size_blocks / 512

--- a/benchs/fio_zone_mixed.py
+++ b/benchs/fio_zone_mixed.py
@@ -26,6 +26,10 @@ class Run(Bench):
     def run(self, dev, container):
         extra = ''
         max_open_zones = 14
+        output_path_prefix = "output"
+
+        if container == 'no':
+            output_path_prefix = self.output
 
         if is_dev_zoned(dev):
             # Zone Capacity (52% of zone size)
@@ -46,7 +50,7 @@ class Run(Bench):
 
         prep_param = ("--name=prep "
                     " --io_size=%sk"
-                    " --output output/%s.log") % (io_size, self.jobname)
+                    " --output %s/%s.log") % (io_size, output_path_prefix, self.jobname)
 
         mixs_param = "--name=mix_0_r --wait_for_previous --rw=randread --bs=4k --runtime=180 --ramp_time=30 --time_based --significant_figures=6 --percentile_list=1:5:10:20:30:40:50:60:70:80:90:99:99.9:99.99:99.999:99.9999:99.99999:100 "
         for s in [25, 50, 75, 100, 125, 150, 175, 200, 300, 400, 500, 600, 700, 800, 900, 1000]:
@@ -60,7 +64,7 @@ class Run(Bench):
     def teardown(self, dev, container):
         pass
 
-    def report(self, path):
+    def report(self, dev, path):
 
         csv_data = []
         with open(path + "/" + self.jobname + ".log", 'r') as f:

--- a/benchs/fio_zone_mixed.py
+++ b/benchs/fio_zone_mixed.py
@@ -16,7 +16,7 @@ class Run(Bench):
         return self.jobname
 
     def setup(self, dev, container, output):
-        super(Run, self).setup(output)
+        super(Run, self).setup(output, container)
 
         self.discard_dev(dev)
 
@@ -50,7 +50,7 @@ class Run(Bench):
 
         prep_param = ("--name=prep "
                     " --io_size=%sk"
-                    " --output %s/%s.log") % (io_size, output_path_prefix, self.jobname)
+                    " --output %s/%s.log") % (io_size, self.output, self.jobname)
 
         mixs_param = "--name=mix_0_r --wait_for_previous --rw=randread --bs=4k --runtime=180 --ramp_time=30 --time_based --significant_figures=6 --percentile_list=1:5:10:20:30:40:50:60:70:80:90:99:99.9:99.99:99.999:99.9999:99.99999:100 "
         for s in [25, 50, 75, 100, 125, 150, 175, 200, 300, 400, 500, 600, 700, 800, 900, 1000]:

--- a/benchs/fio_zone_randr_seqw_seqr_rrsw.py
+++ b/benchs/fio_zone_randr_seqw_seqr_rrsw.py
@@ -16,7 +16,7 @@ class Run(Bench):
         return self.jobname
 
     def setup(self, dev, container, output):
-        super(Run, self).setup(output)
+        super(Run, self).setup(output, container)
 
         self.discard_dev(dev)
 
@@ -51,12 +51,12 @@ class Run(Bench):
                     " --max_open_zones=%s"
                     " --filename=%s"
                     " --output %s/%s.log"
-                    " %s") % (max_open_zones, dev, output_path_prefix, self.jobname, extra)
+                    " %s") % (max_open_zones, dev, self.output, self.jobname, extra)
         prep_param = ("--name=prep "
                     " --io_size=%s"
                     " --rw=write "
                     " --bs=16k --iodepth=64"
-                    " --output %s/%s_prep.log") % (io_size, output_path_prefix, self.jobname)
+                    " --output %s/%s_prep.log") % (io_size, self.output, self.jobname)
         fio_param = "%s %s" % (init_param, prep_param)
         self.run_cmd(dev, container, 'fio', fio_param)
 
@@ -69,7 +69,7 @@ class Run(Bench):
                     " --group_reporting"
                     " --filename=%s"
                     " --output %s/%s_rr.log"
-                    " %s") % (dev, output_path_prefix, self.jobname, extra)
+                    " %s") % (dev, self.output, self.jobname, extra)
         # Use offset2 to define size
         rr_param = (" --name=4K_R_READ_256QD_1 --offset=%sm --size=%sm --iodepth=64") % (offset1,  offset3)
         rr_param += (" --name=4K_R_READ_256QD_2 --offset=%sm --size=%sm --iodepth=64") % (offset1, offset3)

--- a/benchs/fio_zone_randr_seqw_seqr_rrsw.py
+++ b/benchs/fio_zone_randr_seqw_seqr_rrsw.py
@@ -26,6 +26,10 @@ class Run(Bench):
     def run(self, dev, container):
         extra = ''
         max_open_zones = 14
+        output_path_prefix = "output"
+
+        if container == 'no':
+            output_path_prefix = self.output
 
         if is_dev_zoned(dev):
             # Zone Capacity (52% of zone size)
@@ -46,13 +50,13 @@ class Run(Bench):
                     " --output-format=json"
                     " --max_open_zones=%s"
                     " --filename=%s"
-                    " --output output/%s.log"
-                    " %s") % (max_open_zones, dev, self.jobname, extra)
+                    " --output %s/%s.log"
+                    " %s") % (max_open_zones, dev, output_path_prefix, self.jobname, extra)
         prep_param = ("--name=prep "
                     " --io_size=%s"
                     " --rw=write "
                     " --bs=16k --iodepth=64"
-                    " --output output/%s_prep.log") % (io_size, self.jobname)
+                    " --output %s/%s_prep.log") % (io_size, output_path_prefix, self.jobname)
         fio_param = "%s %s" % (init_param, prep_param)
         self.run_cmd(dev, container, 'fio', fio_param)
 
@@ -64,8 +68,8 @@ class Run(Bench):
                     " --percentile_list=1:5:10:20:30:40:50:60:70:80:90:99:99.9:99.99:99.999:99.9999:99.99999:100"
                     " --group_reporting"
                     " --filename=%s"
-                    " --output output/%s_rr.log"
-                    " %s") % (dev, self.jobname, extra)
+                    " --output %s/%s_rr.log"
+                    " %s") % (dev, output_path_prefix, self.jobname, extra)
         # Use offset2 to define size
         rr_param = (" --name=4K_R_READ_256QD_1 --offset=%sm --size=%sm --iodepth=64") % (offset1,  offset3)
         rr_param += (" --name=4K_R_READ_256QD_2 --offset=%sm --size=%sm --iodepth=64") % (offset1, offset3)
@@ -89,7 +93,7 @@ class Run(Bench):
     def teardown(self, dev, container):
         pass
 
-    def report(self, path):
+    def report(self, dev, path):
 
         csv_data = []
 

--- a/benchs/fio_zone_throughput_avg_lat.py
+++ b/benchs/fio_zone_throughput_avg_lat.py
@@ -176,7 +176,7 @@ class Run(Bench):
         return self.jobname
 
     def setup(self, dev, container, output):
-        super(Run, self).setup(output)
+        super(Run, self).setup(output, container)
 
         self.discard_dev(dev)
 
@@ -229,7 +229,7 @@ class Run(Bench):
 
                 prep_param = ("--name=prep "
                             " --size=%sz"
-                            " --output %s/%s_prep.log") % (increment_size, output_path_prefix, operation)
+                            " --output %s/%s_prep.log") % (increment_size, self.output, operation)
 
                 fio_param = "%s %s" % (init_param, prep_param)
 
@@ -280,7 +280,7 @@ class Run(Bench):
                                         " --time_based"
                                         " --ramp_time=%s --runtime=%s"
                                         " --percentile_list=1:5:10:20:30:40:50:60:70:80:90:99:99.9:99.99:99.999:99.9999:99.99999:100"
-                                        " --output %s/%s.log") % (operation, size, fio_ramptime, fio_runtime, output_path_prefix, output_name)
+                                        " --output %s/%s.log") % (operation, size, fio_ramptime, fio_runtime, self.output, output_name)
                             fio_param = "%s %s" % (init_param, exec_param)
 
                             self.run_cmd(dev, container, 'fio', fio_param)

--- a/benchs/fio_zone_throughput_avg_lat.py
+++ b/benchs/fio_zone_throughput_avg_lat.py
@@ -187,9 +187,14 @@ class Run(Bench):
         global fio_runtime
         global fio_ramptime
         extra = ''
+        output_path_prefix = "output"
+
+        if container == 'no':
+            output_path_prefix = self.output
+
 
         if not is_dev_zoned(dev):
-            print("This test is ment to be run on a zoned dev")
+            print("This test is meant to be run on a zoned dev")
             sys.exit(1)
 
         dev_number_zones = self.get_number_of_zones(dev)
@@ -224,7 +229,7 @@ class Run(Bench):
 
                 prep_param = ("--name=prep "
                             " --size=%sz"
-                            " --output output/%s_prep.log") % (increment_size, operation)
+                            " --output %s/%s_prep.log") % (increment_size, output_path_prefix, operation)
 
                 fio_param = "%s %s" % (init_param, prep_param)
 
@@ -275,7 +280,7 @@ class Run(Bench):
                                         " --time_based"
                                         " --ramp_time=%s --runtime=%s"
                                         " --percentile_list=1:5:10:20:30:40:50:60:70:80:90:99:99.9:99.99:99.999:99.9999:99.99999:100"
-                                        " --output output/%s.log") % (operation, size, fio_ramptime, fio_runtime, output_name)
+                                        " --output %s/%s.log") % (operation, size, fio_ramptime, fio_runtime, output_path_prefix, output_name)
                             fio_param = "%s %s" % (init_param, exec_param)
 
                             self.run_cmd(dev, container, 'fio', fio_param)
@@ -284,7 +289,7 @@ class Run(Bench):
     def teardown(self, dev, container):
         pass
 
-    def report(self, path):
+    def report(self, dev, path):
 
         csv_data = []
         csv_row = []

--- a/benchs/fio_zone_writes.py
+++ b/benchs/fio_zone_writes.py
@@ -18,7 +18,7 @@ class Run(Bench):
         return self.jobname
 
     def setup(self, dev, container, output):
-        super(Run, self).setup(output)
+        super(Run, self).setup(output, container)
 
         self.discard_dev(dev)
 
@@ -50,7 +50,7 @@ class Run(Bench):
                     " --output=%s/fio_zone_write.log"
                     " --ioengine=libaio --direct=1 --zonemode=zbd"
                     " --name=seqwriter --rw=randwrite"
-                    " --bs=64k --max_open_zones=%s %s") % (dev, io_size, output_path_prefix, output_path_prefix, max_open_zones, extra)
+                    " --bs=64k --max_open_zones=%s %s") % (dev, io_size, self.output, self.output, max_open_zones, extra)
 
         self.run_cmd(dev, container, 'fio', fio_param)
 

--- a/benchs/fio_zone_writes.py
+++ b/benchs/fio_zone_writes.py
@@ -28,6 +28,10 @@ class Run(Bench):
     def run(self, dev, container):
         extra = ''
         max_open_zones = 14
+        output_path_prefix = "output"
+
+        if container == 'no':
+            output_path_prefix = self.output
 
         if is_dev_zoned(dev):
             # Zone Capacity (52% of zone size)
@@ -42,20 +46,20 @@ class Run(Bench):
         fio_param = ("--filename=%s"
                     " --io_size=%sk"
                     " --log_avg_msec=1000"
-                    " --write_bw_log=output/fio_zone_write"
-                    " --output=output/fio_zone_write.log"
+                    " --write_bw_log=%s/fio_zone_write"
+                    " --output=%s/fio_zone_write.log"
                     " --ioengine=libaio --direct=1 --zonemode=zbd"
                     " --name=seqwriter --rw=randwrite"
-                    " --bs=64k --max_open_zones=%s %s") % (dev, io_size, max_open_zones, extra)
+                    " --bs=64k --max_open_zones=%s %s") % (dev, io_size, output_path_prefix, output_path_prefix, max_open_zones, extra)
 
         self.run_cmd(dev, container, 'fio', fio_param)
 
     def teardown(self, dev, container):
         pass
 
-    def report(self, path):
+    def report(self, dev, path):
 
-        devcap = self.get_nvme_drive_capacity_gb(path)
+        devcap = self.get_nvme_drive_capacity_gb(dev, path)
         if devcap is None:
             print("Could not get drive capacity for report")
             sys.exit(1)

--- a/benchs/rocksdb.py
+++ b/benchs/rocksdb.py
@@ -68,7 +68,7 @@ class RocksDBBase(Bench):
                       " --delete_obsolete_files_period_micros=", self.delete_obsolete_files_period, \
                       " --statistics", \
                       ''.join(bench_params), \
-                      " > ", self.output, "/", name, ".txt 2>&1"
+                      " > ", self.output_host_path, "/", name, ".txt 2>&1"
 
         return ''.join(params)
 
@@ -105,7 +105,7 @@ class RocksDBFillPrep(RocksDBBase):
         pass
 
     def setup(self, dev, container, output):
-        super(RocksDBFillPrep, self).setup(output)
+        super(RocksDBFillPrep, self).setup(output, container)
 
         self.discard_dev(dev)
 
@@ -140,7 +140,7 @@ class RocksDBOverwrite(RocksDBBase):
         pass
 
     def setup(self, dev, container, output):
-        super(RocksDBOverwrite, self).setup(output)
+        super(RocksDBOverwrite, self).setup(output, container)
 
     def run(self, dev, container):
         num = str(int(self.scale_num * 0.1))
@@ -171,7 +171,7 @@ class RocksDBReadwhilewriting(RocksDBBase):
         pass
 
     def setup(self, dev, container, output):
-        super(RocksDBReadwhilewriting, self).setup(output)
+        super(RocksDBReadwhilewriting, self).setup(output, container)
 
     def run(self, dev, container):
 

--- a/benchs/rocksdb.py
+++ b/benchs/rocksdb.py
@@ -90,7 +90,7 @@ class RocksDBBase(Bench):
 
                 return [i for i in line.split(' ') if i]
 
-    def report(self, path):
+    def report(self, dev, path):
         devcap = self.get_nvme_drive_capacity_gb(path)
         if devcap is None:
             print("Could not get drive capacity for report")
@@ -120,7 +120,7 @@ class RocksDBFillPrep(RocksDBBase):
 
         self.run_cmd(dev, container, 'db_bench', self.get_run_string(dev, bench_params, self.jobname))
 
-    def report(self, path):
+    def report(self, dev, path):
         filename = path + "/" + self.jobname + ".txt"
         entries = self.get_result_from_test(filename, 'fillrandom')
 
@@ -152,7 +152,7 @@ class RocksDBOverwrite(RocksDBBase):
 
         self.run_cmd(dev, container, 'db_bench', self.get_run_string(dev, bench_params, self.jobname))
 
-    def report(self, path):
+    def report(self, dev, path):
         filename = path + "/" + self.jobname + ".txt"
         entries = self.get_result_from_test(filename, 'overwrite')
 
@@ -218,7 +218,7 @@ class RocksDBReadwhilewriting(RocksDBBase):
 
         return csv_file
 
-    def report(self, path):
+    def report(self, dev, path):
         self.report_bench(path, 'readrandom', 'readrandom')
         self.report_bench(path, 'write', 'readwhilewriting')
         csv_file = self.report_bench(path, 'writelimit', 'readwhilewriting')

--- a/benchs/template.py
+++ b/benchs/template.py
@@ -35,7 +35,7 @@ class Run(Bench):
     def teardown(self, dev, container):
         pass
 
-    def report(self):
+    def report(self, dev, path):
         # return csv_file
         pass
 

--- a/benchs/template.py
+++ b/benchs/template.py
@@ -17,7 +17,7 @@ class Run(Bench):
         return "template"
 
     def setup(self, dev, container, output):
-        super(Run, self).setup(output)
+        super(Run, self).setup(output, container)
 
         self.discard_dev(dev)
 

--- a/benchs/usenix_atc_2021_zns_eval.py
+++ b/benchs/usenix_atc_2021_zns_eval.py
@@ -287,7 +287,7 @@ class Run(Bench):
 
         self.output = root_output
 
-    def report(self, path):
+    def report(self, dev, path):
         csv_files = []
         is_device_zoned = os.path.exists(os.path.join(path, "zenfs"))
         subpaths = self.get_filesystems_to_test(is_device_zoned)

--- a/benchs/usenix_atc_2021_zns_eval.py
+++ b/benchs/usenix_atc_2021_zns_eval.py
@@ -176,7 +176,7 @@ class Run(Bench):
 
 
     def setup(self, dev, container, output):
-        super(Run, self).setup(output)
+        super(Run, self).setup(output, container)
         self.discard_dev(dev)
         self.target_fz_base = self.get_target_fz_base(dev)
         if is_dev_zoned(dev):
@@ -186,7 +186,7 @@ class Run(Bench):
 
     def create_mountpoint(self, dev, filesystem):
         relative_mountpoint = "%s_%s" % (dev.strip('/dev/'), filesystem)
-        mountpoint = os.path.join(self.output, relative_mountpoint)
+        mountpoint = os.path.join(self.output_host_path, relative_mountpoint)
         os.mkdir(mountpoint)
         return mountpoint, relative_mountpoint
 
@@ -259,7 +259,10 @@ class Run(Bench):
             return self.conventional_filesystems
 
     def run(self, dev, container):
-        root_output = self.output
+        root_output = self.output_host_path
+        # Backup self.output as we will modify it
+        bkup_output = self.output
+
         is_device_zoned = is_dev_zoned(dev)
         for filesystem in self.get_filesystems_to_test(is_device_zoned):
             mountpoint = ''
@@ -285,7 +288,7 @@ class Run(Bench):
                 if self.conv_nullblk_dev != '':
                     self.destroy_nullblk_dev(self.conv_nullblk_dev)
 
-        self.output = root_output
+        self.output = bkup_output
 
     def report(self, dev, path):
         csv_files = []

--- a/run.py
+++ b/run.py
@@ -163,7 +163,7 @@ def run_benchmarks(dev, container, benches, run_output, scheduler_overwrite):
         b.setup(dev, container, run_output)
         b.run(dev, container)
         b.teardown(dev, container)
-        csv_file = b.report(run_output)
+        csv_file = b.report(dev, run_output)
         b.plot(csv_file)
 
     print("\nCompleted %s benchmark(s)" % len(benches))


### PR DESCRIPTION
    - For '-c no' option, scripts were failing as o/p folder path was incorrect.
      Fixed it to point to same folder layout as with '-c yes' option.
    - Pass dev to Report method to correctly identify if device is zoned.
    - Minor typos & README corrections.
    - Make '--privileged' part of default cmdline while launching the container.

Signed-off-by: Indraneel M <Indraneel.Mukherjee@wdc.com>