### PR TITLE
fix(f8a727a): Set mq-deadline scheduler for iodepth > 1

### DIFF
--- a/benchs/fio_zone_mixed.py
+++ b/benchs/fio_zone_mixed.py
@@ -10,7 +10,7 @@ class Run(Bench):
         pass
 
     def get_default_device_scheduler(self):
-        return DeviceScheduler.NONE
+        return DeviceScheduler.MQ_DEADLINE
 
     def id(self):
         return self.jobname

--- a/benchs/fio_zone_randr_seqw_seqr_rrsw.py
+++ b/benchs/fio_zone_randr_seqw_seqr_rrsw.py
@@ -10,7 +10,7 @@ class Run(Bench):
         pass
 
     def get_default_device_scheduler(self):
-        return DeviceScheduler.NONE
+        return DeviceScheduler.MQ_DEADLINE
 
     def id(self):
         return self.jobname


### PR DESCRIPTION
For zoned fio workloads with iodepth > 1 the default scheduler should be mq-deadline.