### PR TITLE
fix: Enable `norandommap` option for random fio workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ Overwrite benchmark run with the mq-deadline device scheduler:
 Benchmarks
 ----------
 
-All fio benchmarks are setting the none scheduler by default if the iodepth is 1.
+- All fio benchmarks are setting the none scheduler by default if the iodepth is 1.
+- When doing random fio workloads, the `norandommap` fio option is set.
 
 SPDK FIO plugin support:
   - Following benchmarks have SPDK FIO plugin support

--- a/benchs/fio_zone_mixed.py
+++ b/benchs/fio_zone_mixed.py
@@ -58,6 +58,7 @@ class Run(Bench):
                       f" --max_open_zones={max_open_zones}"
                       f" --filename={dev}"
                       f" --rw=randwrite"
+                      f" --norandommap"
                       f" --bs=64k"
                       f" {extra}")
 
@@ -68,6 +69,7 @@ class Run(Bench):
         mixs_param = ("--name=mix_0_r"
                       " --wait_for_previous"
                       " --rw=randread"
+                      " --norandommap"
                       " --bs=4k"
                       " --runtime=180"
                       " --ramp_time=30"
@@ -83,6 +85,7 @@ class Run(Bench):
                            f" --time_based"
                            f" --name=mix_{s}_r"
                            f" --rw=randread"
+                           f" --norandommap"
                            f" --bs=4k"
                            f" --runtime=180"
                            f" --ramp_time=30"

--- a/benchs/fio_zone_throughput_avg_lat.py
+++ b/benchs/fio_zone_throughput_avg_lat.py
@@ -112,6 +112,7 @@ class Run(Bench):
                             f" --numjobs={numjobs}"
                             f" --group_reporting"
                             f" --rw=write"
+                            f" --norandommap"
                             f" --bs={block_size}"
                             f" {extra}")
 
@@ -210,6 +211,7 @@ class Run(Bench):
                                         f" --max_open_zones={dev_max_open_zones}"
                                         f" --filename={dev}"
                                         f" --rw={operation}"
+                                        f" --norandommap"
                                         f" --bs={block_size}"
                                         f" {extra}")
 

--- a/benchs/fio_zone_writes.py
+++ b/benchs/fio_zone_writes.py
@@ -60,7 +60,7 @@ class Run(Bench):
                      " --write_bw_log=%s/fio_zone_write"
                      " --output=%s/fio_zone_write.log"
                      " --direct=1 --zonemode=zbd"
-                     " --name=seqwriter --rw=randwrite"
+                     " --name=seqwriter --rw=randwrite --norandommap"
                      " --bs=64k --max_open_zones=%s %s") % (dev,
                                                             io_size,
                                                             self.result_path(),


### PR DESCRIPTION
When running random fio workloads that cover more than the capacity of the file descriptor range, the randommap will issue the same IO pattern after all blocks of the specified file descriptor range where covered.

We want random behavior also with overwrites, therefore we enable the `norandommap` option.