### PR TITLE
refactor: Change throuput graph to use bars

### DIFF
--- a/plotter/matplotlib_plotter.py
+++ b/plotter/matplotlib_plotter.py
@@ -172,7 +172,7 @@ class Plot(object):
         min_throughput -= 20
         if min_throughput < 0:
             min_throughput = 0
-        ax = df.plot(marker='o', xlim=(-.5, (len(benchmarking_labels)/number_datapoints)-0.5), ylim=(min_throughput, max_throughput + 200), figsize=(15,7.5))
+        ax = df.plot.bar(xlim=(-.5, (len(benchmarking_labels)/number_datapoints)-0.5), ylim=(min_throughput, max_throughput + 200), figsize=(15,7.5))
 
         #Disable x ticks and regular labels
         ax.set_xticklabels('')


### PR DESCRIPTION
Use bars for the indivitual throughput values in
fio_zone_throughput_avg_lat plots instead of connected dots. This improves readablity.